### PR TITLE
bar height patch added

### DIFF
--- a/Patches/dwm-bar-height-6.2.diff
+++ b/Patches/dwm-bar-height-6.2.diff
@@ -1,0 +1,25 @@
+diff --git a/config.def.h b/config.def.h
+index 1c0b587..9814500 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -5,6 +5,7 @@ static const unsigned int borderpx  = 1;        /* border pixel of windows */
+ static const unsigned int snap      = 32;       /* snap pixel */
+ static const int showbar            = 1;        /* 0 means no bar */
+ static const int topbar             = 1;        /* 0 means bottom bar */
++static const int user_bh            = 0;        /* 0 means that dwm will calculate bar height, >= 1 means dwm will user_bh as bar height */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+ static const char col_gray1[]       = "#222222";
+diff --git a/dwm.c b/dwm.c
+index 4465af1..2c27cb3 100644
+--- a/dwm.c
++++ b/dwm.c
+@@ -1545,7 +1545,7 @@ setup(void)
+ 	if (!drw_fontset_create(drw, fonts, LENGTH(fonts)))
+ 		die("no fonts could be loaded.");
+ 	lrpad = drw->fonts->h;
+-	bh = drw->fonts->h + 2;
++	bh = user_bh ? user_bh : drw->fonts->h + 2;
+ 	updategeom();
+ 	/* init atoms */
+ 	utf8string = XInternAtom(dpy, "UTF8_STRING", False);


### PR DESCRIPTION
This patch allows user to change dwm's default bar height.

Change user_bh variable in you're config.h If user_bh is equal to 0 dwm will calculate bar height like it did before.

static const int user_bh = 0; /* 0 means that dwm will calculate bar height, >= 1 means dwm will user_bh as bar height */